### PR TITLE
imdb Top250 speed up

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.metadatautils"
        name="Metadata and Artwork module"
-       version="1.0.19"
+       version="1.0.20"
        provider-name="marcelveldt">
     <requires>
         <import addon="xbmc.python" version="2.24.0"/>

--- a/lib/helpers/animatedart.py
+++ b/lib/helpers/animatedart.py
@@ -19,17 +19,18 @@ class AnimatedArt(object):
     def __init__(self, simplecache=None, kodidb=None):
         '''Initialize - optionaly provide SimpleCache and KodiDb object'''
 
-        if not kodidb:
-            from kodidb import KodiDb
-            self.kodidb = KodiDb()
-        else:
-            self.kodidb = kodidb
-
         if not simplecache:
             from simplecache import SimpleCache
             self.cache = SimpleCache()
         else:
             self.cache = simplecache
+
+        if not kodidb:
+            from kodidb import KodiDb
+            self.kodidb = KodiDb(self.cache)
+        else:
+            self.kodidb = kodidb
+
 
     @use_cache(14)
     def get_animated_artwork(self, imdb_id, manual_select=False, ignore_cache=False):

--- a/lib/helpers/imdb.py
+++ b/lib/helpers/imdb.py
@@ -68,4 +68,5 @@ class Imdb(object):
                     "movieid": kodi_movie["movieid"],
                     "top250": results[imdb_id]
                 }
-                self.kodidb.set_json('VideoLibrary.SetMovieDetails', params)
+                if not ("top250" in kodi_movie and kodi_movie["top250"] == results[imdb_id]):
+                    self.kodidb.set_json('VideoLibrary.SetMovieDetails', params)

--- a/lib/helpers/imdb.py
+++ b/lib/helpers/imdb.py
@@ -24,7 +24,7 @@ class Imdb(object):
             self.cache = simplecache
         if not kodidb:
             from kodidb import KodiDb
-            self.kodidb = KodiDb()
+            self.kodidb = KodiDb(self.cache)
         else:
             self.kodidb = kodidb
 

--- a/lib/helpers/kodidb.py
+++ b/lib/helpers/kodidb.py
@@ -11,7 +11,7 @@ from utils import try_parse_int, localdate_from_utc_string, localized_date_time
 from kodi_constants import *
 from operator import itemgetter
 import arrow
-
+import datetime
 
 class KodiDb(object):
     '''various methods and helpers to get data from kodi json api'''
@@ -39,7 +39,11 @@ class KodiDb(object):
         # apparently you can't filter on imdb so we have to do this the complicated way
         if KODI_VERSION > 16:
             # from Kodi 17 we have a uniqueid field instead of imdbnumber
-            all_items = self.get_json('VideoLibrary.GetMovies', fields=["uniqueid"], returntype="movies")
+            all_items = self.cache.get("kodidb.all_movies_uniqueids")
+            if not all_items:
+                all_items = self.get_json('VideoLibrary.GetMovies', fields=["uniqueid"], returntype="movies")
+                self.cache.set("kodidb.all_movies_uniqueids", all_items, expiration=datetime.timedelta(minutes=15))
+
             for item in all_items:
                 for item2 in item["uniqueid"].values():
                     if item2 == imdb_id:

--- a/lib/helpers/kodidb.py
+++ b/lib/helpers/kodidb.py
@@ -406,8 +406,7 @@ class KodiDb(object):
                     "album": item.get("album"),
                     "artist": item.get("artist"),
                     "votes": item.get("votes"),
-                    "trailer": item.get("trailer"),
-                    "progress": item.get('progresspercentage')
+                    "trailer": item.get("trailer")
                 }
                 if item["type"] == "episode":
                     infolabels["season"] = item["season"]

--- a/lib/helpers/kodidb.py
+++ b/lib/helpers/kodidb.py
@@ -16,6 +16,14 @@ import arrow
 class KodiDb(object):
     '''various methods and helpers to get data from kodi json api'''
 
+    def __init__(self, simplecache=None):
+        '''Initialize - optionaly provide simplecache object'''
+        if not simplecache:
+            from simplecache import SimpleCache
+            self.cache = SimpleCache()
+        else:
+            self.cache = simplecache
+
     def movie(self, db_id):
         '''get moviedetails from kodi db'''
         return self.get_json("VideoLibrary.GetMovieDetails", returntype="moviedetails",

--- a/lib/metadatautils.py
+++ b/lib/metadatautils.py
@@ -314,7 +314,7 @@ class MetadataUtils(object):
         '''public kodidb object - for lazy loading'''
         if not self._kodidb:
             from helpers.kodidb import KodiDb
-            self._kodidb = KodiDb()
+            self._kodidb = KodiDb(self.cache)
         return self._kodidb
 
     @property


### PR DESCRIPTION
On RPI3 with 1500 movies took VideoLibrary.GetMovies over 10 seconds, so we can cache results for while. And with my setup of skin Eminence.2 metadatautils are initialized 4 times and update of top250 run also 4 times, so this really helped.

Remove non exists infoLabel progress from kodidb.create_listitem
